### PR TITLE
Exit process if master server panics

### DIFF
--- a/master_server/src/exit_on_panic.rs
+++ b/master_server/src/exit_on_panic.rs
@@ -1,0 +1,22 @@
+#![macro_use]
+
+// Shuts down the process if this struct's destructor is called as a result of a panic.
+pub struct ExitOnPanic;
+impl Drop for ExitOnPanic {
+    fn drop(&mut self) {
+        use std::{thread,process};
+        if thread::panicking() {
+            process::exit(1); //Goodbye, cruel world!
+        }
+    }
+}
+
+// This macro takes an expression. If a panic occurs, then the process exits. Otherwise, the result of the expression is returned.
+macro_rules! exit_on_panic {
+    ($x:expr) => (
+        {
+            let _eop_struct = exit_on_panic::ExitOnPanic;
+            $x
+        }
+    )
+}

--- a/master_server/src/main.rs
+++ b/master_server/src/main.rs
@@ -41,6 +41,7 @@ extern crate time;
 use time::{SteadyTime,Duration};
 
 mod error_macros;
+mod exit_on_panic;
 
 mod halo_server;
 use halo_server::HaloServer;
@@ -93,14 +94,14 @@ fn main() {
     let servers_mut_destruction = servers_mut_udp.clone();
 
     // Destruction thread. This will remove servers that have not broadcasted their presence in a while.
-    let _ = Builder::new().name(DESTRUCTION_THREAD_NAME.to_owned()).spawn(move || {
+    let _ = Builder::new().name(DESTRUCTION_THREAD_NAME.to_owned()).spawn(move || exit_on_panic!({
         loop {
             thread::sleep_ms(10 * 1000);
             let mut servers = servers_mut_destruction.lock().unwrap();
             let timenow = SteadyTime::now();
             servers.retain(|x| x.last_alive + Duration::seconds(DROP_TIME) > timenow);
         }
-    });
+    }));
 
     // Blacklist mutex. Concurrency needs to be safe, my friend.
     let blacklist: Option<Vec<String>> = None;
@@ -108,7 +109,7 @@ fn main() {
     let blacklist_udp = blacklist_update.clone();
 
     // Blacklist read thread.
-    let _ = Builder::new().name(BLACKLIST_THREAD_NAME.to_owned()).spawn(move || {
+    let _ = Builder::new().name(BLACKLIST_THREAD_NAME.to_owned()).spawn(move || exit_on_panic!({
         let valid_line = |x: &str| -> bool { x.trim().len() > 0 && !x.starts_with("#") };
         loop {
             // Placed in a block so blacklist is unlocked before sleeping to prevent threads from being locked for too long.
@@ -124,10 +125,10 @@ fn main() {
             }
             thread::sleep_ms(BLACKLIST_UPDATE_TIME * 1000);
         }
-    });
+    }));
 
     // TCP server thread. This is for the HaloMD application.
-    let _ = Builder::new().name(TCP_SERVER_THREAD_NAME.to_owned()).spawn(move || {
+    let _ = Builder::new().name(TCP_SERVER_THREAD_NAME.to_owned()).spawn(move || exit_on_panic!({
         loop {
             for stream in client_socket.incoming() {
                 let mut client = unwrap_option_or_bail!(stream.ok(), { continue });
@@ -156,7 +157,7 @@ fn main() {
                 });
             }
         }
-    });
+    }));
 
     // UDP server is run on the main thread. Servers broadcast their presence here.
 


### PR DESCRIPTION
If any of the threads should ever panic for any reason, then we would
rather have the master server shut down than go into a state where only
part of it functions.